### PR TITLE
Adapting KaTeX Macro

### DIFF
--- a/src/tfl_training_anomaly_detection/constants.py
+++ b/src/tfl_training_anomaly_detection/constants.py
@@ -1,14 +1,14 @@
 # keep in sync with noteboks/_config.yml
 
 LATEX_MACROS = r"""
-$\newcommand{\vect}[1]{{\mathbf{\boldsymbol{#1}} }}$
-$\newcommand{\amax}{{\text{argmax}}}$
-$\newcommand{\P}{{\mathbb{P}}}$
-$\newcommand{\E}{{\mathbb{E}}}$
-$\newcommand{\R}{{\mathbb{R}}}$
-$\newcommand{\Z}{{\mathbb{Z}}}$
-$\newcommand{\N}{{\mathbb{N}}}$
-$\newcommand{\C}{{\mathbb{C}}}$
-$\newcommand{\abs}[1]{{ \left| #1 \right| }}$
-$\newcommand{\simpl}[1]{{\Delta^{#1} }}$
+$\renewcommand{\vect}[1]{{\mathbf{\boldsymbol{#1}} }}$
+$\renewcommand{\amax}{{\text{argmax}}}$
+$\renewcommand{\P}{{\mathbb{P}}}$
+$\renewcommand{\E}{{\mathbb{E}}}$
+$\renewcommand{\R}{{\mathbb{R}}}$
+$\renewcommand{\Z}{{\mathbb{Z}}}$
+$\renewcommand{\N}{{\mathbb{N}}}$
+$\renewcommand{\C}{{\mathbb{C}}}$
+$\renewcommand{\abs}[1]{{ \left| #1 \right| }}$
+$\renewcommand{\simpl}[1]{{\Delta^{#1} }}$
 """


### PR DESCRIPTION
Changing KaTeX macro to `renewcommand`, fixing #63.